### PR TITLE
Run benchmark against main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,12 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
+      - name: Trust Homebrew taps
+        run: |
+          brew tap fluxcd/tap
+          brew tap stefanprodan/tap
+          brew trust fluxcd/tap
+          brew trust stefanprodan/tap
       - name: Install tools
         run: make tools
       - name: Create cluster

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # flux-benchmark
 
+<!-- benchmark control PR: compare current main -->
+
 [![benchmark](https://github.com/fluxcd/flux-benchmark/actions/workflows/test.yaml/badge.svg)](https://github.com/fluxcd/flux-benchmark/actions/workflows/test.yaml)
 
 **Mean Time To Production** benchmarks

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # flux-benchmark
 
-<!-- benchmark control PR: compare current main -->
-
 [![benchmark](https://github.com/fluxcd/flux-benchmark/actions/workflows/test.yaml/badge.svg)](https://github.com/fluxcd/flux-benchmark/actions/workflows/test.yaml)
 
 **Mean Time To Production** benchmarks


### PR DESCRIPTION
Control PR to trigger the benchmark workflow against current main for comparison with Flux 2.9 results.\n\nThe only code change is the Homebrew tap trust workflow fix needed for CI to install the benchmark tools.